### PR TITLE
Fix configure for symlinked /usr/bin64/

### DIFF
--- a/src/configure.ac
+++ b/src/configure.ac
@@ -298,7 +298,7 @@ AC_ARG_WITH([qwt],
     else
       AC_MSG_NOTICE((1) did not found libqwt.so in /usr/local)
       AC_MSG_NOTICE((2) search for libqwt.so in /usr/lib64)
-      qwt=`find /usr/lib64 -name libqwt.so -print 2>/dev/null | sort | tail -1 | sed -e 's|/lib64/libqwt.so||'`
+      qwt=`find /usr/lib64/ -name libqwt.so -print 2>/dev/null | sort | tail -1 | sed -e 's|/lib64/libqwt.so||'`
       if test -n "${qwt}"; then
          AC_MSG_NOTICE([(2) we found libqwt.so under ${qwt} - OK])
          AC_SUBST(QWT, [${qwt}])


### PR DESCRIPTION
On some systems /usr/bin64 (which is a fallback search path
for liibqwt.so on configure) is a symlink. "find" exits
directly when passed a symlink without trailing slash, while
a path with trailing slash will resolve the symlink and
search the directory correctly.

This does not affect systems with a regular /usr/lib64.